### PR TITLE
linter導入と指摘対応

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,8 @@
+# https://pub.dev/packages/pedantic_mono
+include: package:pedantic_mono/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_classes_with_only_static_members: false
+    constant_identifier_names: true
+    prefer_relative_imports: true

--- a/lib/counter_page.dart
+++ b/lib/counter_page.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:riverpods_sample/state/color.dart';
-import 'package:riverpods_sample/state/counter.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'state/color.dart';
+import 'state/counter.dart';
+
 class CounterPage extends ConsumerWidget {
+  const CounterPage({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
@@ -13,18 +16,18 @@ class CounterPage extends ConsumerWidget {
             // 「カラー状態のコントローラー」を WidgetRef 経由で取得して
             // カラー変更メソッドを実行する
             onPressed: ref.read(colorProvider.notifier).changeColor,
-            icon: Icon(Icons.update),
+            icon: const Icon(Icons.update),
           )
         ],
       ),
-      body: Center(
+      body: const Center(
         child: _ColorfulCounterText(),
       ),
       floatingActionButton: FloatingActionButton(
         // 「カウント状態のコントローラー」を WidgetRef 経由で取得して
         // カウントをインクリメントするメソッドを実行する
         onPressed: ref.read(counterProvider.notifier).incrementCounter,
-        child: Icon(Icons.add),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:riverpods_sample/counter_page.dart';
+
+import 'counter_page.dart';
 
 void main() {
   runApp(
-    ProviderScope(
+    const ProviderScope(
       child: MyApp(),
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       home: CounterPage(),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -55,6 +55,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -67,6 +74,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
@@ -95,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  pedantic_mono:
+    dependency: "direct dev"
+    description:
+      name: pedantic_mono
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.19.2"
   riverpod:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic_mono: ^1.19.0+1
 
 flutter:
   uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:riverpods_sample/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(const MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
linter導入とその指摘の対応を行いました。

### やったこと

- 愛用している [pedantic_mono](https://pub.dev/packages/pedantic_mono) を導入
  - 一部指摘を次のようにカスタマイズしています

```
linter:
  rules:
    avoid_classes_with_only_static_members: false
    constant_identifier_names: true
    prefer_relative_imports: true
```

- pedantic_mono の指摘の対応