### PR TITLE
StateNotifierProviderの状態更新処理に関するコメントを修正しました

### DIFF
--- a/lib/state/counter.dart
+++ b/lib/state/counter.dart
@@ -20,11 +20,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// final counter = ref.watch(counterProvider);
 /// ```
 ///
-/// カウント状態を更新（インクリメント）したいときは次のように書きます。
+/// ElevatedButton等のonPressedの中でカウント状態を更新（インクリメント）したいときは、
+/// 次のように書きます。
 /// ```
-/// onPressed: () {
 ///   ref.read(counterProvider.notifier).update((state) => state + 1);
-/// },
+/// ```
+/// 今回のCountNotifierのように、
+/// 状態を更新(インクリメント)するメソッド(incrementCounter)を実装している場合は、
+/// 次のように書くことで状態の更新をメソッドを用いて行うこともできます。
+/// ```
+///   ref.read(counterProvider.notifier).incrementCounter;
 /// ```
 /// 参考サイト: https://riverpod.dev/docs/providers/state_provider/#how-to-update-the-state-based-on-the-previous-value-without-reading-the-provider-twice
 final counterProvider = StateNotifierProvider.autoDispose<CounterNotifier, int>(


### PR DESCRIPTION
表題の通り、StateNotifierProvider の値の更新に関するコメントを修正しました。

修正点
- ref.read をonPressedで囲んでいたのを、削除し、
前の文にElevatedButton等のonPressedの中でという表現を追加しました。
初心者が見た際に、「StateNotifierProviderの値を更新する際にはonPressedから書くんだ！」と勘違いされないようにするための修正となります。

 - 状態の更新処理の方法として``ref.read(counterProvider.notifier).incrementCounter;``の方法について追加、説明しました。
 状態の更新処理として``update``を紹介しているのに、counter_page.dartでの実装が``incrementCounter``を使った方法となっている点が気になりました。
実装の内容を説明するため、この説明文を追加しました。

以上、レビューのほど、よろしくお願いします！