### PR TITLE
onPressedに渡す関数を匿名関数で包む

### DIFF
--- a/lib/counter_page.dart
+++ b/lib/counter_page.dart
@@ -15,7 +15,7 @@ class CounterPage extends ConsumerWidget {
           IconButton(
             // 「カラー状態のコントローラー」を WidgetRef 経由で取得して
             // カラー変更メソッドを実行する
-            onPressed: ref.read(colorProvider.notifier).changeColor,
+            onPressed: () => ref.read(colorProvider.notifier).changeColor(),
             icon: const Icon(Icons.update),
           )
         ],
@@ -26,7 +26,7 @@ class CounterPage extends ConsumerWidget {
       floatingActionButton: FloatingActionButton(
         // 「カウント状態のコントローラー」を WidgetRef 経由で取得して
         // カウントをインクリメントするメソッドを実行する
-        onPressed: ref.read(counterProvider.notifier).incrementCounter,
+        onPressed: () => ref.read(counterProvider.notifier).incrementCounter(),
         child: const Icon(Icons.add),
       ),
     );


### PR DESCRIPTION
## 概要

`onPressed`に`ref.read(xxxProvider.notifier).yyy`を直接渡してしまうと、`build`メソッドが呼ばれた時点の`xxxProvider`のインスタンスの`yyy`メソッドが`onPressed`に渡されてしまうため、`xxxProvider`が更新されても`onPressed`は古いインスタンスの`yyy`メソッドを参照してしまいます。

（ボタンを追加し、押下時に`ref.refresh(counterProvider)`を呼ぶと、その後+ボタンを押したときに古いインスタンスの`incrementCounter()`メソッドを参照するためクラッシュが発生するのを確認できるかと思います）

## 修正内容

`onPressed`に直接関数を渡すのではなく、匿名関数（[Anonymous functions](https://dart.dev/guides/language/language-tour#anonymous-functions)）で包むようにします。
こうすることで`onPressed`が呼ばれるたびに匿名関数が実行され、その関数内で毎回`ref.read`が実行され最新のインスタンスを取得できます。

riverpodの[ドキュメント](https://riverpod.dev/ja/docs/concepts/reading)でもこの形で実装サンプルが書かれています。