### PR TITLE
riverpodを使えるようにテストを修正

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,6 +6,7 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:riverpods_sample/main.dart';
@@ -13,7 +14,7 @@ import 'package:riverpods_sample/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## 概要

riverpodを使う場合Widgetを`ProviderScope`の子にする必要があります。
テストコードが`ProviderScope`を利用していなかったためテストが失敗していました。

## 修正内容

`MyApp`を`ProviderScope`で囲みました。